### PR TITLE
Fix some cast AI starting dead after completing a level

### DIFF
--- a/code/game/g_save.c
+++ b/code/game/g_save.c
@@ -1793,6 +1793,11 @@ qboolean G_SavePersistant( char *nextmap, int clientNum, int persid ) {
 		clientNum = 0;
 	}
 
+	if ( g_entities[clientNum].r.svFlags & SVF_CASTAI ) {
+		G_DPrintf( "G_SavePersistant: %d: Skipping cast AI client\n", clientNum );
+		return qfalse;
+	}
+
 	G_DPrintf( "G_SavePersistant: %d\n", clientNum );
 
 	// open the file
@@ -1857,6 +1862,11 @@ void G_LoadPersistant( int clientNum ) {
 	// dont error out, the less we crash the server, the better
 	if ( clientNum < 0 || clientNum >= MAX_COOP_CLIENTS ) {
 		clientNum = 0;
+	}
+
+	if ( g_entities[clientNum].r.svFlags & SVF_CASTAI ) {
+		G_DPrintf( "G_LoadPersistant: %d: Skipping cast AI client\n", clientNum );
+		return;
 	}
 
 	filename = va( "save\\current%d.psw", clientNum );


### PR DESCRIPTION
The persistant data was always written / read for the first 8 clients
(MAX_COOP_CLIENTS). However if sv_maxCoopClients is less than 8, cast
AI clients are in the remaining slots. This means that health, weapon,
etc are saved for some cast AI clients when a level is completed. If
cast AI had 0 health, the cast AI will be dead in the next level.