### PR TITLE
Fixed issue #47: levels list is empty in "Create Server" menu

### DIFF
--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -6878,7 +6878,7 @@ void _UI_Init( qboolean inGameLoad ) {
 //	UI_ParseTeamInfo("teaminfo.txt");
 //	UI_LoadTeams();
 	UI_ParseGameInfo( "coopgameinfo.txt" );
-//	UI_LoadArenas();
+	UI_LoadArenas();
 
 	menuSet = UI_Cvar_VariableString( "ui_menuFiles" );
 	if ( menuSet == NULL || menuSet[0] == '\0' ) {


### PR DESCRIPTION
This problem was introduced by commit
3fe1b103df06b50e9e367539fc97757224ede642