### PR TITLE
MAX_GAMESTATE_CHARS exceeded error

### DIFF
--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -1323,7 +1323,7 @@ typedef enum {
 
 #define RESERVED_CONFIGSTRINGS  2   // game can't modify below this, only the system can
 
-#define MAX_GAMESTATE_CHARS 16000
+#define MAX_GAMESTATE_CHARS 32000
 typedef struct {
 	int stringOffsets[MAX_CONFIGSTRINGS];
 	char stringData[MAX_GAMESTATE_CHARS];

--- a/code/splines/q_splineshared.h
+++ b/code/splines/q_splineshared.h
@@ -1304,7 +1304,7 @@ typedef enum {
 
 #define RESERVED_CONFIGSTRINGS  2   // game can't modify below this, only the system can
 
-#define MAX_GAMESTATE_CHARS 16000
+#define MAX_GAMESTATE_CHARS 32000
 typedef struct {
 	int stringOffsets[MAX_CONFIGSTRINGS];
 	char stringData[MAX_GAMESTATE_CHARS];


### PR DESCRIPTION
I've caught a error "MAX_GAMESTATE_CHARS exceeded" several times when playing
with upgraded coop:
https://www.moddb.com/mods/rtcw-classic-cooperative-campaign/downloads/upgrade

This commit workarounds the problem